### PR TITLE
Change cors config

### DIFF
--- a/src/main/java/com/patternpedia/api/config/ResourceServerConfig.java
+++ b/src/main/java/com/patternpedia/api/config/ResourceServerConfig.java
@@ -61,7 +61,8 @@ class ResourceServerConfig extends ResourceServerConfigurerAdapter {
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowCredentials(true);
-        config.addAllowedOrigin("*");
+        config.addAllowedOrigin("http://localhost:4200");
+        config.addAllowedOrigin("http://localhost:4201");
         config.addAllowedHeader("*");
         config.addAllowedMethod("*");
         source.registerCorsConfiguration("/**", config);

--- a/src/main/java/com/patternpedia/api/config/ResourceServerConfig.java
+++ b/src/main/java/com/patternpedia/api/config/ResourceServerConfig.java
@@ -61,7 +61,7 @@ class ResourceServerConfig extends ResourceServerConfigurerAdapter {
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowCredentials(true);
-        config.addAllowedOrigin("http://localhost:4200");
+        config.addAllowedOrigin("*");
         config.addAllowedHeader("*");
         config.addAllowedMethod("*");
         source.registerCorsConfiguration("/**", config);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,8 +1,8 @@
-server.port=8082
+server.port=8080
 
-spring.datasource.url=jdbc:postgresql://localhost:5432/patterns
-spring.datasource.username=planqk
-spring.datasource.password=planqk
+spring.datasource.url=jdbc:postgresql://localhost:5432/patternpedia
+spring.datasource.username=patternpedia
+spring.datasource.password=patternpedia
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
 spring.jpa.hibernate.ddl-auto=update

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,8 +1,8 @@
-server.port=8080
+server.port=8082
 
-spring.datasource.url=jdbc:postgresql://localhost:5432/patternpedia
-spring.datasource.username=patternpedia
-spring.datasource.password=patternpedia
+spring.datasource.url=jdbc:postgresql://localhost:5432/patterns
+spring.datasource.username=planqk
+spring.datasource.password=planqk
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
 spring.jpa.hibernate.ddl-auto=update


### PR DESCRIPTION
Currently CORS is configured to only allow access by "http://localhost:4200". Since now multiple frontends access the backend of the Pattern Atlas (Pattern-Atlas-UI and Atlas-UI), this hardcoded address is not enough. Therefore the CORS config has been adjusted.